### PR TITLE
feature-issue18-adjust_sentence_and_picture

### DIFF
--- a/style-sass.css
+++ b/style-sass.css
@@ -58,7 +58,7 @@
 .category-interview .wp-block-image {
   position: relative;
   overflow: hidden;
-  width: 80%;
+  width: 100%;
 }
 
 .category-interview .wp-block-image:before {


### PR DESCRIPTION
## Related issue
No: #18 

## What is an issue
LPの画像と文章の見え方を整える

## How to solve it
.category-interview .wp-block-imageのwidthを80%→100%にする

## Considerable affects
特になし