### PR TITLE
fix width

### DIFF
--- a/style.css
+++ b/style.css
@@ -577,6 +577,9 @@ dialog[open]{
 		padding: 10px 0;
 		width: 100%;
 	}
+	.front-page #main .main-inner{
+		padding: 0;
+	}
 	.sns-btn{
 		font-size: 40px;
 	}


### PR DESCRIPTION
スマフォ画面のホームページの幅に若干の空白があったので、@media内のpaddingを0にすることで幅を広げました。

![home_before](https://user-images.githubusercontent.com/64079253/85835992-e3bb3980-b7d0-11ea-9fba-2a33db36f0f8.png)
![home_after](https://user-images.githubusercontent.com/64079253/85835998-e584fd00-b7d0-11ea-9732-06f480a7df83.png)
