### PR TITLE
fix width

### DIFF
--- a/style.css
+++ b/style.css
@@ -550,6 +550,7 @@ dialog[open]{
 	/* contact */
 	div .wpcf7{
 		padding: 0;
+		width: 100%;
 	}
 
 	/* btn */


### PR DESCRIPTION
iphone7以前のwidthだと写真1枚目のように文字がはみ出てしまってました。
写真2枚目のセレクタのwidthを100％にすることで解決しました。

![inquiry_before](https://user-images.githubusercontent.com/64079253/85837191-b40d3100-b7d2-11ea-964b-4e220d20418e.png)
![inquiry_problem](https://user-images.githubusercontent.com/64079253/85837198-b5d6f480-b7d2-11ea-8cca-103c9e76669e.png)
![inquiry_after](https://user-images.githubusercontent.com/64079253/85837211-b96a7b80-b7d2-11ea-9d71-5b08c2193269.png)
