### PR TITLE
change how to comment out

### DIFF
--- a/categories/normal.php
+++ b/categories/normal.php
@@ -102,8 +102,7 @@ $my_query = new wp_query( $args );
 			</div><!-- /main-inner -->
 		</div><!-- /main -->
 
-	<!-- <?php get_sidebar(); ?> -->
-
+		</*?php get_sidebar(); ?*/>
 	</div><!-- /wrap -->
 
 </div><!-- /content -->

--- a/front-page.php
+++ b/front-page.php
@@ -45,7 +45,7 @@
 				</div><!-- /main-inner -->
 		</div><!-- /main -->
 		
-		<!-- <?php get_sidebar(); ?> -->
+		</*?php get_sidebar(); ?*/>
 
 	</div><!-- /wrap -->
   

--- a/index.php
+++ b/index.php
@@ -69,7 +69,7 @@
 			</div><!-- /main-inner -->
 		</div><!-- /main -->
 	
-	<!-- <?php get_sidebar(); ?>-->
+		</*?php get_sidebar(); ?*/>
 	
 
 	</div><!-- /wrap -->

--- a/page-consulting.php
+++ b/page-consulting.php
@@ -39,7 +39,7 @@
 			</div><!-- /main-inner -->
 		</div><!-- /main -->
 
-	<!-- <?php get_sidebar(); ?> -->
+	</*?php get_sidebar(); ?*/>
 
 	</div><!-- /wrap -->
 

--- a/pages/interview.php
+++ b/pages/interview.php
@@ -67,7 +67,7 @@
 	
 	</div><!-- /main -->
 	
-	<!-- <?php get_sidebar(); ?> -->
+	</*?php get_sidebar(); ?*/>
 
 		<?php do_action( 'xeory_append_wrap' ); ?>
 

--- a/pages/normal.php
+++ b/pages/normal.php
@@ -82,8 +82,7 @@
 	
 	</div><!-- /main -->
 	
-	<!-- <?php get_sidebar(); ?> -->
-	
+	</*?php get_sidebar(); ?*/>	
 
 		<?php do_action( 'xeory_append_wrap' ); ?>
 


### PR DESCRIPTION
phpの構文にhtmlのコメントアウトを使っていたため、コメントアウトの1部がテキストとして表示されていました。
phpのコメントアウトの方法に変えることで解決しました。
全ページ確認済です。
![スクリーンショット (25)](https://user-images.githubusercontent.com/64079253/86107858-614ab680-bafd-11ea-97df-e0723b8e11de.png)
